### PR TITLE
fix: fail-after number of iterations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,6 @@ jobs:
     - name: Test `fail-after` is triggered
       id: test_fail-after
       uses: ./.github/actions/testing
-      continue-on-error: true
       with:
         head-ref: "test-0001-base-ref"
         base-ref: "test-0001-head-ref"

--- a/action.yml
+++ b/action.yml
@@ -116,26 +116,33 @@ runs:
         export GITHUB_BASE_REF
         export GITHUB_HEAD_REF
         echo "::endgroup::"
+        set -euo pipefail
         bash ${{ github.action_path }}/src/scripts/fetch_through_merge_base.sh        
-    - id: fallback 
-      if: ${{ steps.fetch_through_merge_base.conclusion == 'failure' && inputs.fallback-fetch-all }}
-      shell: bash
-      env:
-        WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: |
-        echo "::group::Falling back to fetching all...🚦"
-        cd $WORKING_DIRECTORY;
-        git fetch --all --unshallow;
-        python ${{ github.action_path }}/src/scripts/git_ungraft.py;
-        echo "::endgroup::"
+    # Note: `outcome` does not consider `continue-on-error`
+    # Note: fallback-fetch-all is a string, not a boolean, since type is not supported
+    # for inputs on composite actions (only workflows).
     - id: check_for_failure
-      if: ${{ steps.fetch_through_merge_base.conclusion == 'failure' }} 
+      if: ${{ steps.fetch_through_merge_base.outcome == 'failure' && inputs.fallback-fetch-all == 'false' }}
       shell: bash
       env:
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         echo "Action failed! ❌"
         exit 1
+    - id: fallback 
+      if: ${{ steps.fetch_through_merge_base.outcome == 'failure' && inputs.fallback-fetch-all == 'true' }}
+      shell: bash
+      env:
+        BASE_REF: ${{ steps.fetch_through_merge_base.outputs.base-ref }}
+        HEAD_REF: ${{ steps.fetch_through_merge_base.outputs.head-ref }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: |
+        echo "::group::Falling back to fetching all...🚦"
+        cd $WORKING_DIRECTORY;
+        git fetch --all --unshallow --verbose;
+        python ${{ github.action_path }}/src/scripts/git_ungraft.py;
+        echo -n "Verifying merge-base: "
+        git merge-base $BASE_REF $HEAD_REF
     - id: finalize
       if: always()
       shell: bash
@@ -148,6 +155,7 @@ runs:
         cd $WORKING_DIRECTORY;
         ancestor_ref="$(git merge-base $BASE_REF $HEAD_REF)";
         echo "ancestor-ref=${ancestor_ref}" >> $GITHUB_OUTPUT
-        echo ${ancestor_ref}
         echo "::endgroup::"
+        echo "Merge base is:"
+        echo ${ancestor_ref}
         echo "Action succeeded! ✅"

--- a/src/scripts/fetch_through_merge_base.sh
+++ b/src/scripts/fetch_through_merge_base.sh
@@ -56,11 +56,7 @@ python ${SCRIPT_DIR}/git_ungraft.py;
 
 # keep fetching deeper until we find the common ancestor reference
 while [ -z "$( git merge-base "__github_base_ref__" "__github_head_ref__" )" ]; do
-  # fetch deeper
-  git fetch --quiet --update-shallow --deepen="$DEEPEN_LENGTH" origin "$GITHUB_HEAD_REF";
-  git fetch --quiet --update-shallow --deepen="$DEEPEN_LENGTH" origin "$GITHUB_BASE_REF";
-  python ${SCRIPT_DIR}/git_ungraft.py;
-  # check if we are done iterating
+ # check if we are done iterating
   set +e;
   let FAIL_AFTER="FAIL_AFTER-1";
   set -e;
@@ -69,11 +65,14 @@ while [ -z "$( git merge-base "__github_base_ref__" "__github_head_ref__" )" ]; 
     echo "Failure! ❌"
     echo "::endgroup::"
     exit 1;
-  else
-    echo "Deepend search by ${DEEPEN_LENGTH}‼️";
-    echo "::endgroup::"
-    echo "::group::Attempts remaining: ${FAIL_AFTER} 🚦"
   fi
+  # fetch deeper
+  git fetch --quiet --update-shallow --deepen="$DEEPEN_LENGTH" origin "$GITHUB_HEAD_REF";
+  git fetch --quiet --update-shallow --deepen="$DEEPEN_LENGTH" origin "$GITHUB_BASE_REF";
+  python ${SCRIPT_DIR}/git_ungraft.py;
+  echo "Deepend search by ${DEEPEN_LENGTH}‼️";
+  echo "::endgroup::"
+  echo "::group::Attempts remaining: ${FAIL_AFTER} 🚦"
 done
 
 echo "Success! ✅"

--- a/src/scripts/git_ungraft.py
+++ b/src/scripts/git_ungraft.py
@@ -184,6 +184,8 @@ def _main(args: argparse.Namespace) -> None:
     prefix = "Would ungraft " if args.dry_run else "Ungrafted "
     for item in candidates:
         print(prefix + item)
+    if 0 == len(candidates):
+        print("No candidate commits to ungrafft")
 
 def _parse_args(args: List[str]) -> argparse.Namespace:
     _log.debug("Parsing args: %s", args)


### PR DESCRIPTION
1. Types are not supported on (composite) actions and we were treating `fallback-fetch-all` as a boolean, whereas it really was a `string`.
2. We need to use `outcome` not `conclusion`, since the latter will always be true when `continue-on-error` is set to `true`.
3. If we have no more iterations to go, then we ALSO do one final fetch (and ungraft), which after fixing the above, breaks tests.  