### PR TITLE
ci: pin GHA to commit hashes, drop deprecated runners

### DIFF
--- a/.github/actions/testing/action.yml
+++ b/.github/actions/testing/action.yml
@@ -61,7 +61,7 @@ runs:
   using: "composite"
   steps: 
     - name: Checkout mock data
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: fulcrumgenomics/fetch-through-merge-base-mock
         path: __testing_dir__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   on-main-branch-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       on_main: ${{ steps.contains_tag.outputs.retval }}
     steps:
@@ -34,7 +34,7 @@ jobs:
     uses: "./.github/workflows/tests.yml"
 
   make-changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: publish-to-pypi
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
@@ -55,7 +55,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
   make-github-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: github
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   on-main-branch-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       on_main: ${{ steps.contains_tag.outputs.retval }}
     steps:
@@ -17,11 +17,11 @@ jobs:
       - name: git config --global remote.origin.followRemoteHEAD never
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: rickstaa/action-contains-tag@v1
+      - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308 # v1.2.10
         id: contains_tag
         with:
           reference: "main"
@@ -34,19 +34,19 @@ jobs:
     uses: "./.github/workflows/tests.yml"
 
   make-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: publish-to-pypi
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Generate a Changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
         id: git-cliff
         with:
           config: pyproject.toml
@@ -55,7 +55,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
   make-github-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: github
     permissions:
       contents: write
@@ -63,14 +63,14 @@ jobs:
     needs: make-changelog
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           name: ${{ github.ref_name }}
           body: ${{ needs.make-changelog.outputs.release_body }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: npm ci
       - run: npm run build
       - run: npm run format-check
@@ -41,11 +41,11 @@ jobs:
   testing:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-14, macos-13]
+        os: [ubuntu-24.04, ubuntu-22.04, macos-15, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Test main versus main
       uses: ./.github/actions/testing
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
       run: |
         cat ${GITHUB_ACTION_PATH}/src/misc/banner.txt
     - id: setup-gha-timer
-      uses: fulcrumgenomics/gha-timer@v1
+      uses: fulcrumgenomics/gha-timer@6c2d3c71524c884b8b472fb888ff25fbc4d24e61 # v1.1.0
       with:
         skip-banner: true
     - id: fetch_through_merge_base


### PR DESCRIPTION
## Summary

- Drop `ubuntu-20.04` and `macos-13` from the test matrix — both were removed by GitHub and caused jobs to queue indefinitely or get cancelled (see PR #55)
- Add `macos-15` as replacement for `macos-13`; new matrix: `[ubuntu-24.04, ubuntu-22.04, macos-15, macos-14]`
- Pin `ubuntu-latest` to `ubuntu-24.04` in the release workflow for reproducibility
- Pin all third-party actions to full commit SHAs with version comments for supply-chain safety:
  - `actions/checkout` v4.3.1
  - `actions/setup-node` v4.4.0
  - `rickstaa/action-contains-tag` v1.2.10
  - `orhun/git-cliff-action` v4.7.1
  - `softprops/action-gh-release` v2.6.1
  - `fulcrumgenomics/gha-timer` v1.1.0

## Test plan

- [ ] Verify all 4 matrix jobs (ubuntu-24.04, ubuntu-22.04, macos-15, macos-14) pass in CI
- [ ] Verify the build job passes