### PR TITLE
fix: explicitly install python via actions/setup-python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,11 @@ runs:
       shell: bash
       run: |
         cat ${GITHUB_ACTION_PATH}/src/misc/banner.txt
+    - id: setup-python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: "3.12"
+        update-environment: false
     - id: setup-gha-timer
       uses: fulcrumgenomics/gha-timer@6c2d3c71524c884b8b472fb888ff25fbc4d24e61 # v1.1.0
       with:
@@ -144,7 +149,7 @@ runs:
         gha-timer start --name "Falling back to fetching all...🚦"
         cd $WORKING_DIRECTORY;
         git fetch --all --unshallow --verbose;
-        python ${{ github.action_path }}/src/scripts/git_ungraft.py;
+        "${{ steps.setup-python.outputs.python-path }}" ${{ github.action_path }}/src/scripts/git_ungraft.py;
         echo -n "Verifying merge-base: "
         gha-timer elapsed --outcome success --name "Falling back to fetching all...🚦"
         git merge-base $BASE_REF $HEAD_REF


### PR DESCRIPTION
## Summary

- Install Python 3.12 explicitly via `actions/setup-python` with `update-environment: false` so it doesn't pollute the runner's global PATH
- Reference the installed Python via `steps.setup-python.outputs.python-path` in the fallback step that runs `git_ungraft.py`
- Action pinned to commit hash with version comment (`v5.6.0`)

Closes #32

## Test plan

- [ ] Verify the `testing (ubuntu-*)` and `testing (macos-*)` matrix jobs pass
- [ ] Verify the `fallback-fetch-all` test step (which exercises the Python script) succeeds