### PR TITLE
ci: bump gha-timer to v1.1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         python-version: "3.12"
         update-environment: false
     - id: setup-gha-timer
-      uses: fulcrumgenomics/gha-timer@6c2d3c71524c884b8b472fb888ff25fbc4d24e61 # v1.1.0
+      uses: fulcrumgenomics/gha-timer@d0d886fa587c7f4f714e64d84aa6e274e818d48b # v1.1.1
       with:
         skip-banner: true
     - id: fetch_through_merge_base


### PR DESCRIPTION
## Summary
- Bump `fulcrumgenomics/gha-timer` from `v1.1.0` (`6c2d3c71...`) to `v1.1.1` (`d0d886fa...`) in `action.yml`.

## Why
The org policy \"all actions must be pinned to a full-length commit SHA\" applies through the entire transitive chain. `gha-timer@v1.1.0`'s composite action resolved `actions/setup-python@v5` at runtime and was rejected — see PR #58, [failing run](https://github.com/fulcrumgenomics/fetch-through-merge-base/actions/runs/24697745825/job/72237701086?pr=58).

`gha-timer@v1.1.1` (fulcrumgenomics/gha-timer#12, released via fulcrumgenomics/gha-timer#13) pins every third-party action by SHA, so this bump unblocks PR #58 and any other consumers under the policy.

No behavioral change.

## Notes
- The `gha-timer` publish workflow's \"Update the latest tag\" step failed (missing `git config user.email`/`user.name` on the runner) so the moving `v1` tag wasn't refreshed. Unrelated to this bump since we pin by SHA; worth a follow-up fix in `gha-timer`.

## Test plan
- [ ] This workflow run passes the org SHA-pin check (previously blocked at the `actions/setup-python@v5` resolution)
- [ ] `tests` matrix jobs (ubuntu-24.04, ubuntu-22.04, macos-15, macos-14) all green