### PR TITLE
chore: release v1.4.3 and repair release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,36 @@ jobs:
           reference: "main"
           tag: "${{ github.ref_name }}"
 
+  check-version:
+    runs-on: ubuntu-latest
+    needs: on-main-branch-check
+    if: ${{ needs.on-main-branch-check.outputs.on_main == 'true' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Verify package.json version matches tag
+        shell: bash
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          expected="${TAG_REF#v}"
+          actual=$(node -p "require('./package.json').version")
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Tag ${TAG_REF} does not match package.json version ${actual}. Run 'npm version --no-git-tag-version ${expected}' before tagging."
+            exit 1
+          fi
+
   tests:
     name: tests
-    needs: on-main-branch-check
+    needs: [on-main-branch-check, check-version]
     if: ${{ needs.on-main-branch-check.outputs.on_main == 'true' }}
     uses: "./.github/workflows/tests.yml"
 
   make-changelog:
     runs-on: ubuntu-latest
-    needs: publish-to-pypi
+    needs: tests
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
@@ -49,7 +70,7 @@ jobs:
         uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
         id: git-cliff
         with:
-          config: pyproject.toml
+          config: cliff.toml
           args: --latest --verbose
         env:
           GITHUB_REPO: ${{ github.repository }}
@@ -77,11 +98,13 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Update the latest tag
+      - name: Update the floating major-version tag
         shell: bash
+        env:
+          TAG_REF: ${{ github.ref_name }}
         run: |
-          latest_tag=$(echo "${{ github.ref_name }}" | cut -c -2)
-          git tag -d "${latest_tag}" || echo ""
-          git tag -a -m "Release version ${{ github.ref_name }}" "${latest_tag}"
-          git push origin ":refs/tags/${latest_tag}" || echo ""
-          git push origin "${latest_tag}"
+          major_tag="${TAG_REF%%.*}"
+          git tag -d "${major_tag}" || echo ""
+          git tag -a -m "Release version ${TAG_REF}" "${major_tag}"
+          git push origin ":refs/tags/${major_tag}" || echo ""
+          git push origin "${major_tag}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v1.4.3] (2026-04-20)
+
+- Fix: parent extraction no longer matches commit message body lines that start with `parent ` (#58)
+- Feature: use `gha-timer` for step timing and log grouping, and skip its banner (#35, #36)
+- Feature: add a release workflow that publishes a GitHub Release and updates the floating major-version tag on tag push (#35)
+- CI: pin GitHub Actions by commit SHA with trailing version comments; drop deprecated runners (#56)
+- CI: bump `gha-timer` to v1.1.1 (#59)
+- Fix: explicitly install Python 3.12 via `actions/setup-python` instead of relying on the runner's default (#57)
+- Documentation: update Fulcrum Genomics logo to support light/dark themes; fix logo links (#39, #55)
+- Chore: remove unused dependabot config; bump dev dependencies (#38)
+
+[v1.4.3]: https://github.com/fulcrumgenomics/fetch-through-merge-base/releases/tag/v1.4.3
+
 ## [v1.4.2] (2025-03-19)
 
 - [#31] Fix `fail-after` number of iterations and related tests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,30 +1,40 @@
 # Release
 
-- Ensure the [CHANGELOG](./CHANGELOG.md) is up-to-date.
+Releases are produced by pushing a `vX.Y.Z` tag to `main`. The
+[`publish` workflow](./.github/workflows/release.yml) then runs the test suite,
+generates a changelog with [git-cliff](https://git-cliff.org/), and creates a
+GitHub Release, also moving the floating major-version tag (e.g. `v1`) to the
+new commit.
 
-- Ensure that `package.json` and `package-lock.json` have the correct `version` property (use `npm version --no-git-tag-version X.Y.Z`).
+All contributions land on `main` via pull request; there is no separate
+`develop` branch.
 
-- If this release is a major version, update all the example YAML in the
-  [README](./README.md), e.g. `2.0.0` would need `@v1` -> `@v2`.
+## Cutting a release
 
-- All contributions currently go to the `develop` branch. To make a new
-  release, checkout to the `main` branch and merge with `develop` and then proceed
-  with the release process.
+1. Ensure the [CHANGELOG](./CHANGELOG.md) has an entry for `vX.Y.Z`.
 
-```bash
-git checkout develop
-git pull origin develop
-git checkout main
-git pull origin main
-git merge develop
-git push origin main
-```
+2. Bump `package.json` and `package-lock.json` to the new version:
 
-- Create a new named tag:
+   ```bash
+   npm version --no-git-tag-version X.Y.Z
+   ```
 
-```bash
-git tag -a -m 'Release version vX.Y.Z'
-```
+   The `check-version` job in the `publish` workflow compares `package.json`
+   to the tag and fails the release if they don't match.
 
-Replace `X.Y.Z` by the appropriate version number.
+3. If this is a major version bump, update all example YAML in the
+   [README](./README.md) (e.g. `@v1` → `@v2`).
 
+4. Open a pull request with the above changes and merge it to `main`.
+
+5. Tag the merge commit on `main` and push the tag:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   git tag -a -m 'Release version vX.Y.Z' vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   Replace `X.Y.Z` with the appropriate version number. Pushing the tag
+   triggers the `publish` workflow.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+# git-cliff configuration for fetch-through-merge-base.
+# Consumed by .github/workflows/release.yml to generate the GitHub Release body.
+
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits -%}
+{%- set subject = commit.message | split(pat="\n") | first | upper_first | trim -%}
+{%- if commit.github.pr_number -%}
+{%- set subject = subject | trim_end_matches(pat=" (#" ~ commit.github.pr_number ~ ")") -%}
+- {% if commit.scope %}*{{ commit.scope }}*: {% endif %}{{ subject }} (#{{ commit.github.pr_number }})
+{% else -%}
+- {% if commit.scope %}*{{ commit.scope }}*: {% endif %}{{ subject }}
+{% endif -%}
+{%- endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+require_conventional = false
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->Features" },
+  { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+  { message = "^perf", group = "<!-- 2 -->Performance" },
+  { message = "^doc", group = "<!-- 3 -->Documentation" },
+  { message = "^test", group = "<!-- 4 -->Tests" },
+  { message = "^refactor", group = "<!-- 5 -->Refactor" },
+  { message = "^ci", group = "<!-- 6 -->CI" },
+  { message = "^build", group = "<!-- 7 -->Build" },
+  { message = "^chore", group = "<!-- 8 -->Chores" },
+  { message = "^revert", group = "<!-- 9 -->Reverts" },
+  { message = "^Merge", skip = true },
+  { message = ".*", group = "<!-- 99 -->Other" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]+.[0-9]+.[0-9]+"
+topo_order = false
+sort_commits = "oldest"
+
+[remote.github]
+owner = "fulcrumgenomics"
+repo = "fetch-through-merge-base"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetch-through-merge-base",
-  "version": "1.3.0",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetch-through-merge-base",
-      "version": "1.3.0",
+      "version": "1.4.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-through-merge-base",
-  "version": "1.3.0",
+  "version": "1.4.3",
   "description": "fetch through merge base",
   "scripts": {
     "build": "tsc && node lib/misc/generate-docs.js",


### PR DESCRIPTION
## Summary
- Release **v1.4.3** — parent-parsing bug fix, pinned-by-SHA GitHub Actions, explicit Python install, `gha-timer` bump, dependabot cleanup, and logo/doc updates since v1.4.2.
- Repair `.github/workflows/release.yml` so it actually runs on tag push. It has never succeeded since being added in #35: `make-changelog` declared `needs: publish-to-pypi` (a job that doesn't exist) and pointed git-cliff at a non-existent `pyproject.toml`.
- Add a `check-version` job that compares `package.json` to the pushed tag and fails the release on mismatch — closes the drift that left `package.json` pinned at `1.3.0` through both v1.4.1 and v1.4.2.
- Add a minimal `cliff.toml` for git-cliff; groups by conventional-commit type and de-duplicates the PR number when the commit subject already contains it.
- Fix the floating major-version tag extraction from `cut -c -2` (breaks at `v10+`) to `${TAG_REF%%.*}`.
- Bump `package.json`/`package-lock.json` to `1.4.3` and add the CHANGELOG entry.
- Update `RELEASE.md` to document the current main-only flow.

## Reading order
1. `dd72aa1` — workflow fixes, `cliff.toml`, `RELEASE.md`
2. `8f77ffa` — version bump + CHANGELOG

## Test plan
- [ ] `tests.yml` workflow passes on this branch
- [ ] After merge: push `v1.4.3` tag; confirm `publish` workflow runs end-to-end (tests → changelog → GitHub Release → `v1` tag moved)