### PR TITLE
fix(ci): set git identity for annotated major-version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
         env:
           TAG_REF: ${{ github.ref_name }}
         run: |
+          # Annotated tags require a committer identity, which the runner
+          # does not have by default. Use the default github-actions[bot].
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           major_tag="${TAG_REF%%.*}"
           git tag -d "${major_tag}" || echo ""
           git tag -a -m "Release version ${TAG_REF}" "${major_tag}"


### PR DESCRIPTION
## Summary

The `v1.4.3` publish run failed at the "Update the floating major-version tag" step with:

```
Committer identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

`git tag -a -m` (annotated tag) requires a committer identity, which the GitHub Actions runner has none of by default. As a result, the step **deleted** the local `v1` tag but failed before pushing the new one, leaving `origin/v1` pointing at the previous release (`v1.4.2`, commit `8cae4af`).

This PR configures the default `github-actions[bot]` identity at the top of the step so annotated tag creation works on subsequent releases.

## Note

`origin/v1` is currently stale (still at `v1.4.2`). It needs to be force-updated to `139073a` (the `v1.4.3` commit) out of band, since the workflow does not re-run on merges to `main`. Merging this PR alone does **not** fix the already-stale `v1` tag.

## Test plan
- [ ] CI on this branch passes
- [ ] Next release (`v1.4.4`) sees the "Update the floating major-version tag" step succeed and push `v1 -> <new commit>`