### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v1.5.0] (2026-04-21)
+
+- Feature: drop the Python dependency — `git_ungraft` is now a pure-bash helper, and `actions/setup-python` is no longer installed (#62)
+- Feature: `gha-timer` is now opt-out via a new `enable-timing` input (default `'true'`); set `enable-timing: 'false'` to skip installing it. When `gha-timer` is absent, the wrapper falls back to `::group::`/`::endgroup::` workflow commands so logs stay collapsible (#62)
+- Fix: `git_fetch_parents` was a silent no-op on shallow-boundary commits — the exact case it exists to handle. Rewritten to read parents via `git cat-file -p` + awk header parser; regression test added (#62)
+- CI: add a `shellcheck` job (strictest severity) and a `shell-tests` matrix (ubuntu/macos) running new unit tests for `git_ungraft.sh`, `git_fetch_parents.sh`, and `gha_timer_wrapper.sh` (#62)
+- CI: set git identity before creating the annotated major-version tag in the release workflow (#61)
+
+[v1.5.0]: https://github.com/fulcrumgenomics/fetch-through-merge-base/releases/tag/v1.5.0
+
 ## [v1.4.3] (2026-04-20)
 
 - Fix: parent extraction no longer matches commit message body lines that start with `parent ` (#58)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetch-through-merge-base",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetch-through-merge-base",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-through-merge-base",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "fetch through merge base",
   "scripts": {
     "build": "tsc && node lib/misc/generate-docs.js",


### PR DESCRIPTION
## Summary

Cut **v1.5.0** — minor release covering two unreleased commits on `main`:

- `ebacf96` feat: drop python dependency; make gha-timer opt-out (#62)
- `bad50f4` fix(ci): set git identity before creating annotated major-version tag (#61)

## Changes in this PR

- `CHANGELOG.md` — prepend `## [v1.5.0] (2026-04-21)` section
- `package.json` + `package-lock.json` — bump `1.4.3` → `1.5.0`

## CHANGELOG entry

- Feature: drop the Python dependency — `git_ungraft` is now a pure-bash helper, and `actions/setup-python` is no longer installed (#62)
- Feature: `gha-timer` is now opt-out via a new `enable-timing` input (default `'true'`); set `enable-timing: 'false'` to skip installing it. When `gha-timer` is absent, the wrapper falls back to `::group::`/`::endgroup::` workflow commands so logs stay collapsible (#62)
- Fix: `git_fetch_parents` was a silent no-op on shallow-boundary commits — the exact case it exists to handle. Rewritten to read parents via `git cat-file -p` + awk header parser; regression test added (#62)
- CI: add a `shellcheck` job (strictest severity) and a `shell-tests` matrix (ubuntu/macos) running new unit tests for `git_ungraft.sh`, `git_fetch_parents.sh`, and `gha_timer_wrapper.sh` (#62)
- CI: set git identity before creating the annotated major-version tag in the release workflow (#61)

## Follow-up

After this PR is merged, tag the merge commit on `main`:

\`\`\`
git checkout main && git pull origin main
git tag -a -m 'Release version v1.5.0' v1.5.0
git push origin v1.5.0
\`\`\`

Pushing the tag triggers \`.github/workflows/release.yml\` which runs the test suite, generates the GitHub Release via \`git-cliff\`, and moves the floating \`v1\` tag. This is the first real exercise of the git-identity fix from #61.

## Test plan

- [ ] CI green on this PR (tests + shellcheck + shell-tests)
- [ ] After merge: \`check-version\` job passes (confirms \`package.json.version == v1.5.0\`)
- [ ] After tag push: GitHub Release created for \`v1.5.0\`
- [ ] After tag push: floating \`v1\` tag resolves to the \`v1.5.0\` commit