### PR TITLE
fix(test): portable stat invocation in test_git_ungraft

### DIFF
--- a/tests/test_git_ungraft.sh
+++ b/tests/test_git_ungraft.sh
@@ -82,9 +82,17 @@ shallow_before="$(cat "${shallow_file}")"
 # therefore changes its inode.  An mtime check is unreliable because
 # git's shallow-handling code may touch `.git/shallow` in place during
 # read-only sub-commands run by the script, producing flaky failures.
-inode_before="$(stat -f %i "${shallow_file}" 2>/dev/null || stat -c %i "${shallow_file}")"
+#
+# stat invocation is portable: try GNU (`-c %i`) first and fall back
+# to BSD (`-f %i`).  The reverse order is a cross-platform trap — on
+# GNU stat, `-f` is filesystem-info mode, which ignores `%i` and
+# dumps a multi-line blob of free-block / free-inode counts.  Those
+# counts tick between back-to-back calls on a busy CI runner, so
+# two "before"/"after" captures would differ even when the file's
+# real inode is unchanged, producing a cross-platform flake.
+inode_before="$(stat -c %i "${shallow_file}" 2>/dev/null || stat -f %i "${shallow_file}")"
 output="$(bash "${UNGRAFT}")"
-inode_after="$(stat -f %i "${shallow_file}" 2>/dev/null || stat -c %i "${shallow_file}")"
+inode_after="$(stat -c %i "${shallow_file}" 2>/dev/null || stat -f %i "${shallow_file}")"
 if [ "${output}" != "No candidate commits to ungraft" ]; then
     echo "FAIL (case 1): expected 'No candidate commits to ungraft'"
     echo "  got: ${output}"
@@ -156,10 +164,10 @@ echo "Ungraftable candidate: ${ungraftable}"
 # --- case 2: --dry-run prints candidates without rewriting ---
 # As in case 1, use inode identity to detect the script's `mv`-based
 # rewrite; mtime is unreliable here (see case 1 comment).
-inode_before="$(stat -f %i "${shallow_file}" 2>/dev/null || stat -c %i "${shallow_file}")"
+inode_before="$(stat -c %i "${shallow_file}" 2>/dev/null || stat -f %i "${shallow_file}")"
 contents_before="$(cat "${shallow_file}")"
 dry_output="$(bash "${UNGRAFT}" --dry-run)"
-inode_after="$(stat -f %i "${shallow_file}" 2>/dev/null || stat -c %i "${shallow_file}")"
+inode_after="$(stat -c %i "${shallow_file}" 2>/dev/null || stat -f %i "${shallow_file}")"
 if ! grep -qxF "Would ungraft ${ungraftable}" <<< "${dry_output}"; then
     echo "FAIL (case 2): expected 'Would ungraft ${ungraftable}' in dry-run output"
     echo "--- dry-run output ---"


### PR DESCRIPTION
## Summary

Fixes the intermittent `FAIL (case 2): --dry-run replaced .git/shallow (inode changed)` failure in `tests/test_git_ungraft.sh` on ubuntu-* runners.

## Root cause

`stat -f %i file` is BSD syntax (macOS) for "print the inode number". On GNU stat (Linux), `-f` is **filesystem-info mode** — `%i` is ignored as a format spec and `stat` instead prints a multi-line blob of filesystem statistics (free blocks, free inodes, block size, etc.).

The test used

```sh
stat -f %i "${shallow_file}" 2>/dev/null || stat -c %i "${shallow_file}"
```

On Linux, the BSD call "succeeded" (exit 0) with multi-line filesystem info, so the `||` never fell through to the correct GNU form. The captured string contained time-varying free-block counts, so two "before"/"after" captures differed even when the real inode of `.git/shallow` was unchanged — producing a spurious "inode changed" failure whenever the filesystem ticked between calls.

## Verification

Investigated on a temporary instrumented branch (`nh13/investigate-ungraft-flake`) with `strace -f` and `sha256sum` around the dry-run invocation on ubuntu-24.04 (git 2.53.0):

```
[case 2 pre]  inode=8389540 sha256=294569b2…49cdf5d
[case 2 post] inode=8389540 sha256=294569b2…49cdf5d
strace: 2 openat(O_RDONLY) calls; 0 writes/renames/unlinks touching .git/shallow
PASS (case 2)
```

- Contents unchanged (sha256 identical).
- Real inode unchanged.
- No git subprocess writes to `.git/shallow` during `--dry-run`.

The underlying invariant of the test is sound — just tested incorrectly on Linux.

## The fix

Swap the invocation order so GNU stat is tried first and BSD is the fallback:

```sh
stat -c %i "${shallow_file}" 2>/dev/null || stat -f %i "${shallow_file}"
```

Applied in both case 1 and case 2. Added a comment explaining the cross-platform trap so future readers don't revert it.

## Test plan

- [ ] CI green across the full `shell-tests` matrix (ubuntu-22.04, ubuntu-24.04, macos-14, macos-15)
- [ ] Re-run the `shell-tests (ubuntu-*)` jobs a few times to confirm the flake is gone

## Notes

No release needed — this affects only the test suite. The shipped v1.5.0 action is unaffected.